### PR TITLE
delete function now works

### DIFF
--- a/server/db/migrations/20241011162251_create_posts_table.js
+++ b/server/db/migrations/20241011162251_create_posts_table.js
@@ -9,6 +9,7 @@ exports.up = function (knex) {
         table.text('body').notNullable();
         table.integer('user_id').notNullable();
         table.foreign('user_id').references('id').inTable('users');
+        table.timestamps(true, true);
     });
 };
 
@@ -17,5 +18,9 @@ exports.up = function (knex) {
  * @returns { Promise<void> }
  */
 exports.down = function (knex) {
-    return knex.schema.dropTable('posts');
+    return knex.schema.hasTable('posts').then((exists) => {
+        if (exists) {
+            return knex.schema.dropTable('posts');
+        }
+    });
 };

--- a/server/db/migrations/20241011163600_create_comments_table.js
+++ b/server/db/migrations/20241011163600_create_comments_table.js
@@ -6,10 +6,11 @@ exports.up = function (knex) {
     return knex.schema.createTable('comments', (table) => {
         table.increments('id').primary();
         table.integer('post_id').notNullable();
-        table.foreign('post_id').references('id').inTable('posts');
+        table.foreign('post_id').references('id').inTable('posts').onDelete('CASCADE');;
         table.text('content').notNullable();
         table.integer('user_id').notNullable();
         table.foreign('user_id').references('id').inTable('users');
+        table.timestamps(true, true);
     });
 };
 

--- a/server/db/migrations/20241011164337_create_post_tags_table.js
+++ b/server/db/migrations/20241011164337_create_post_tags_table.js
@@ -6,7 +6,7 @@ exports.up = function (knex) {
     return knex.schema.createTable('post_tags', (table) => {
         table.increments('id').primary();
         table.integer('post_id').notNullable();
-        table.foreign('post_id').references('id').inTable('posts');
+        table.foreign('post_id').references('id').inTable('posts').onDelete('CASCADE');;
         table.integer('tag_id').notNullable();
         table.foreign('tag_id').references('id').inTable('tags');
     });
@@ -17,6 +17,9 @@ exports.up = function (knex) {
  * @returns { Promise<void> }
  */
 exports.down = function (knex) {
-    return knex.schema.dropTable('post_tags');
-
+    return knex.schema.hasTable('post_tags').then((exists) => {
+        if (exists) {
+            return knex.schema.dropTable('post_tags');
+        }
+    });
 };

--- a/server/db/migrations/20241011165348_create_liked_posts_table.js
+++ b/server/db/migrations/20241011165348_create_liked_posts_table.js
@@ -6,7 +6,7 @@ exports.up = function (knex) {
     return knex.schema.createTable('liked_posts', (table) => {
         table.increments('id').primary();
         table.integer('post_id').notNullable();
-        table.foreign('post_id').references('id').inTable('posts');
+        table.foreign('post_id').references('id').inTable('posts').onDelete('CASCADE');;
         table.integer('user_id').notNullable();
         table.foreign('user_id').references('id').inTable('users');
     });

--- a/server/db/seeds/07_liked_post_seeds.js
+++ b/server/db/seeds/07_liked_post_seeds.js
@@ -1,0 +1,16 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> } 
+ */
+exports.seed = async function (knex) {
+  // Deletes ALL existing entries
+  await knex('liked_posts').del()
+  await knex('liked_posts').insert([
+    { post_id: 1, user_id: 3 },
+    { post_id: 1, user_id: 2 },
+    { post_id: 2, user_id: 3 },
+    { post_id: 2, user_id: 1 },
+    { post_id: 3, user_id: 1 },
+    { post_id: 3, user_id: 2 },
+  ]);
+};


### PR DESCRIPTION
In this PR, I've edited the migrations files so that now posts can be deleted and all foreign keys that depend on the post table will deleted as well. I've also added time columns to relevant tables. If you're pulling these changes, it might require that you rollback all of your migrations and run them again.