### PR TITLE
food banks fixed

### DIFF
--- a/frontend/src/components/DisplayFoodBanks.jsx
+++ b/frontend/src/components/DisplayFoodBanks.jsx
@@ -5,7 +5,8 @@ import { MotionConfig, motion } from "framer-motion";
 
 function DisplayFoodBanks() {
     const [initialFoodBanks, setInitialFoodBanks] = useState([]);
-    const { setError, filteredFoodBanks } = useContext(FilteredFoodBanksContext);
+    const { setError, filteredFoodBanks, currentPage, setCurrentPage } = useContext(FilteredFoodBanksContext);
+    const itemLimit = 5;
     const fetchInitialBanks = async () => {
         const [data, error] = await fetchHandler('https://data.cityofnewyork.us/resource/if26-z6xq.json');
         console.log(data);
@@ -21,6 +22,20 @@ function DisplayFoodBanks() {
             setError(error)
         }
     }
+    const foodBanksToDisplay = filteredFoodBanks.length > 0 ? filteredFoodBanks : initialFoodBanks;
+    const totalPages = Math.ceil(foodBanksToDisplay.length / itemLimit);
+    const startIndex = (currentPage - 1) * itemLimit;
+    const endIndex = startIndex + itemLimit;
+    const currentBanks = foodBanksToDisplay.slice(startIndex, endIndex);
+
+    const handleNextPage = () => {
+        setCurrentPage((prev) => prev + 1);
+    }
+
+    const handlePrevPage = () => {
+        setCurrentPage((prev) => Math.max(prevPage - 1, 1));
+    }
+
     useEffect(() => {
         fetchInitialBanks();
     }, [])
@@ -28,7 +43,7 @@ function DisplayFoodBanks() {
     return (
         <div className="display_list">
             <ul>
-                {(filteredFoodBanks.length > 0 ? filteredFoodBanks : initialFoodBanks).map((bank) => (
+                {(currentBanks).map((bank) => (
                     <li key={bank.object_id}>
                         <MotionConfig
                             transition={{
@@ -51,6 +66,15 @@ function DisplayFoodBanks() {
                     </li>
                 ))}
             </ul>
+            <div className="pagination">
+                <button onClick={handlePrevPage} disabled={currentPage === 1}>
+                    Previous
+                </button>
+                <span>Page {currentPage} of {totalPages}</span>
+                <button onClick={handleNextPage} disabled={currentPage === totalPages}>
+                    Next
+                </button>
+            </div>
         </div>
     )
 }

--- a/frontend/src/components/FilterFoodBanks.jsx
+++ b/frontend/src/components/FilterFoodBanks.jsx
@@ -5,10 +5,11 @@ import { MotionConfig, motion } from "framer-motion";
 
 function FilterFoodBanks() {
     const boroughs = ['Bronx', 'Brooklyn', 'Manhattan', 'Queens', 'Staten Island'];
-    const [selectedBoro, setSelectedBoro] = useState('');
-    const { setFilteredFoodBanks, setError } = useContext(FilteredFoodBanksContext);
+    const [selectedBoro, setSelectedBoro] = useState(boroughs[0]);
+    const { setFilteredFoodBanks, setError, setCurrentPage } = useContext(FilteredFoodBanksContext);
     const handleSelectedBoro = (event) => {
         setSelectedBoro(event.target.value)
+        setCurrentPage(1);
     };
     const handleSubmit = async (event) => {
         event.preventDefault();
@@ -21,6 +22,8 @@ function FilterFoodBanks() {
         }
 
     };
+
+
     return (
         <div>
             <form onSubmit={handleSubmit}>

--- a/frontend/src/contexts/FilteredFoodBanksContextProvider.jsx
+++ b/frontend/src/contexts/FilteredFoodBanksContextProvider.jsx
@@ -4,7 +4,8 @@ import { useState } from "react";
 export default function FilteredFoodBanksContextProvider({ children }) {
     const [filteredFoodBanks, setFilteredFoodBanks] = useState([]);
     const [error, setError] = useState(null);
-    const context = { filteredFoodBanks, setFilteredFoodBanks, error, setError }
+    const [currentPage, setCurrentPage] = useState(1);
+    const context = { filteredFoodBanks, setFilteredFoodBanks, error, setError, currentPage, setCurrentPage }
     return (
         <FilteredFoodBanksContext.Provider value={context}>
             {children}


### PR DESCRIPTION
In this PR, I've integrated a pagination-esque format for displaying the foodbanks. Now users do not need to endlessly scroll through the page to view foodbanks. I've also fixed the filtering logic and users can now immediately filter for foodbanks in the Bronx.